### PR TITLE
Flush write buffer before reading

### DIFF
--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -19,6 +19,7 @@ module RubySerial
     CREAD = 0x00000800
     CCTS_OFLOW = 0x00010000 # Clearing this disables RTS AND CTS.
     TCSANOW = 0
+    TCSAFLUSH = 2
     NCCS = 20
 
     DATA_BITS = {
@@ -170,6 +171,10 @@ module RubySerial
     }
 
     class Termios < FFI::Struct
+      TCIFLUSH  = 1  # Discard data received but not yet read.
+      TCOFLUSH  = 2  # Discard data written but not yet sent.
+      TCIOFLUSH = 3  # Discard all pending data.
+
       layout  :c_iflag, :ulong,
               :c_oflag, :ulong,
               :c_cflag, :ulong,
@@ -186,5 +191,6 @@ module RubySerial
     attach_function :close, [:int], :int, blocking: true
     attach_function :write, [:int, :pointer,  :int],:int, blocking: true
     attach_function :read, [:int, :pointer,  :int],:int, blocking: true
+    attach_function :tcflush, [:int, :int],:int, blocking: true
   end
 end

--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -18,8 +18,15 @@ module RubySerial
     CLOCAL = 0x00008000
     CREAD = 0x00000800
     CCTS_OFLOW = 0x00010000 # Clearing this disables RTS AND CTS.
-    TCSANOW = 0
-    TCSAFLUSH = 2
+
+    # tcsetattr optional_actions flags
+    # See: https://en.wikibooks.org/wiki/Serial_Programming/termios
+    # And: https://github.com/lattera/glibc/blob/master/bits/termios.h#L324
+    #
+    TCSANOW = 0    # The configuration is changed immediately.
+    TCSADRAIN = 1  # The configuration is changed after all the output written to fd has been transmitted. This prevents the change from corrupting in-transmission data.
+    TCSAFLUSH = 2  # Same as above but any data received and not read will be discarded.
+
     NCCS = 20
 
     DATA_BITS = {

--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -1,5 +1,4 @@
 # Copyright (c) 2014-2016 The Hybrid Group
-
 class Serial
   def initialize(address, baude_rate=9600, data_bits=8, parity=:none)
     file_opts = RubySerial::Posix::O_RDWR | RubySerial::Posix::O_NOCTTY | RubySerial::Posix::O_NONBLOCK
@@ -23,7 +22,7 @@ class Serial
 
     @config = build_config(baude_rate, data_bits, parity)
 
-    err = RubySerial::Posix.tcsetattr(@fd, RubySerial::Posix::TCSANOW, @config)
+    err = RubySerial::Posix.tcsetattr(@fd, RubySerial::Posix::TCSAFLUSH, @config)
     if err == -1
       raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
@@ -55,6 +54,7 @@ class Serial
       end
     end
 
+    RubySerial::Posix.tcflush(@fd, RubySerial::Posix::Termios::TCIOFLUSH)
     # return number of bytes written
     n
   end


### PR DESCRIPTION
On the P4 dev board, the writes are inconsistently delayed, so the reads frequently come back with nothing. Ryan and I tried closing and re-instantiating the `Serial`, but that caused the data to be truncated. 

For reference: https://github.com/lattera/glibc/blob/master/bits/termios.h

/cc @plauche